### PR TITLE
📦️ Update SPM minimum deployment targets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "pilgrim",
     platforms: [
-        .iOS(.v14), .macOS(.v11), .tvOS(.v9),
+        .iOS(.v9), .macOS(.v10_10), .tvOS(.v9),
         .macCatalyst(.v13), .watchOS(.v2), .driverKit(.v19)
     ],
     products: [


### PR DESCRIPTION
## Summary 

The current `Package.swift` is targeting iOS 14 and macOS 11 while the pod spec is targeting 9 and 10.10. This change brings the package in line with podspec